### PR TITLE
docs: add extension to mysql docker file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ $ jhipster-quarkus import-jdl ../gronazon.jh
 
 This time the app relies on MySQL and not h2
 ```
-$ docker-compose -f src/main/docker/mysql up
+$ docker-compose -f src/main/docker/mysql.yml up
 ```
 
 Run the application


### PR DESCRIPTION
The extension seems to be required for docker compose, on Debian at least. Maybe the MacOS version might differ.  Please let me know. Great talk tonight !